### PR TITLE
Fixed Values having multiple `Changed` Connections

### DIFF
--- a/plugin/plugin.moon
+++ b/plugin/plugin.moon
@@ -334,14 +334,14 @@ checkMoonHelper = (obj, force) ->
 -- Check HttpService for StringValue "PlaceName" to see if we should enable persistent mode. --
 checkForPlaceName = (obj) ->
 	-- If the object meets the requirements, enable persistent mode. -- 
-	if #obj.Value > 0
+	if obj.Name == "PlaceName" and #obj.Value > 0
 		resetCache!
 		gameGUID = obj.Value
 		temp = false
 		scan!
 
 placeNameAdded = (obj) ->
-	if obj.Name == "PlaceName" and obj\IsA("StringValue")
+	if obj\IsA("StringValue")
 		checkForPlaceName obj
 		-- Wait for any changes to `PlaceName` in HttpService
 		obj.Changed\connect ->

--- a/plugin/plugin.moon
+++ b/plugin/plugin.moon
@@ -388,6 +388,7 @@ if game.Name\match("Place[%d+]") and
 				
 				doSelection!
 
+		-- Check if we should turn persistent mode on. --
 		for obj in *HttpService\GetChildren!
 			placeNameAdded obj
 			

--- a/plugin/plugin.moon
+++ b/plugin/plugin.moon
@@ -387,11 +387,8 @@ if game.Name\match("Place[%d+]") and
 						checkMoonHelper obj, true
 				
 				doSelection!
-							
-		-- Check if we should turn persistent mode on. --
-		obj = HttpService\FindFirstChild("PlaceName")
+
+		for obj in *HttpService\GetChildren!
+			placeNameAdded obj
 			
 		HttpService.ChildAdded\connect placeNameAdded
-
-		if obj
-			placeNameAdded obj

--- a/plugin/plugin.moon
+++ b/plugin/plugin.moon
@@ -14,7 +14,7 @@ Selection         = game\GetService "Selection"
 UserInputService  = game\GetService "UserInputService"
 
 local hookChanges, sendScript, doSelection, alertBox, alertActive, resetCache, checkMoonHelper
-local justAdded, parseMixinsOut, parseMixinsIn, deleteScript, checkForPlaceName
+local justAdded, parseMixinsOut, parseMixinsIn, deleteScript, checkForPlaceName, placeNameAdded
 
 pmPath      = "Documents\\ROBLOX\\RSync"
 scriptCache = {}
@@ -333,23 +333,19 @@ checkMoonHelper = (obj, force) ->
 
 -- Check HttpService for StringValue "PlaceName" to see if we should enable persistent mode. --
 checkForPlaceName = (obj) ->
-	-- If obj is nil, try to find it. If it is nil, return. --
-	unless obj
-		if HttpService\FindFirstChild "PlaceName"
-			obj = HttpService.PlaceName
-
-	return unless obj
-
-	-- Wait for any changes to objects in HttpService.
-	obj.Changed\connect ->
-		checkForPlaceName obj
-
 	-- If the object meets the requirements, enable persistent mode. -- 
-	if obj\IsA("StringValue") and #obj.Value > 0
+	if #obj.Value > 0
 		resetCache!
 		gameGUID = obj.Value
 		temp = false
 		scan!
+
+placeNameAdded = (obj) ->
+	if obj.Name == "PlaceName" and obj\IsA("StringValue")
+		checkForPlaceName obj
+		-- Wait for any changes to `PlaceName` in HttpService
+		obj.Changed\connect ->
+			checkForPlaceName obj
 
 -- Create the alert box and place it in CoreGui. --
 with alertBox = Instance.new "TextLabel"
@@ -391,7 +387,11 @@ if game.Name\match("Place[%d+]") and
 						checkMoonHelper obj, true
 				
 				doSelection!
-
+							
 		-- Check if we should turn persistent mode on. --
-		checkForPlaceName!
-		HttpService.ChildAdded\connect checkForPlaceName
+		obj = HttpService\FindFirstChild("PlaceName")
+			
+		HttpService.ChildAdded\connect placeNameAdded
+
+		if obj
+			placeNameAdded obj


### PR DESCRIPTION
Previously, every time `Changed` fired on a StringValue it would open up another Changed connection. This behavior is now corrected.

[Relevant lines](https://github.com/evaera/RSync/blob/6a636bcf6787c07ca29f8133b544076a081a0460/plugin/plugin.moon#L335):
335, 344, 345

In addition, checking whether the Object is named `PlaceName` and is a `StringValue` only occurs once.

Should fix [Issue#7](https://github.com/evaera/RSync/issues/7)