### PR TITLE
Fix (most) connection loses

### DIFF
--- a/plugin/plugin.moon
+++ b/plugin/plugin.moon
@@ -188,7 +188,9 @@ startPoll = ->
 	polling = true
 
 	Spawn ->
-		while true
+		-- Waiting here prevents most connection loses
+		-- If polling returns immediatly, it would do 400 requests per minute
+		while wait 0.14 
 			success = pcall ->
 				body = HttpService\GetAsync "http://localhost:#{PORT}/poll", true
 				command = HttpService\JSONDecode body


### PR DESCRIPTION
Everytime I start RSync, I edit the plugin file by changing `while true do` into `while wait(0.14) do`, which drastically lowers the amount of times RSync loses connection. Maybe another part of the code is too greedy with HTTP requests, but (sort of) throttling this loop already improves it a lot.